### PR TITLE
Add sidebar layout and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_FEED_URL=http://localhost:4000

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+Create a `.env.local` file based on `.env.example` to configure the risk feed URL.
+
 First, run the development server:
 
 ```bash

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,20 @@
 'use client';
+import Sidebar from '@/components/Sidebar';
+import Header from '@/components/Header';
 import RiskSummary from '../components/RiskSummary';
 import Exposures from '../components/Exposures';
 
 export default function Home() {
   return (
-    <main className='min-h-screen bg-zinc-900 text-zinc-100 p-4 grid gap-4 lg:grid-cols-2'>
-      <RiskSummary />
-      <Exposures />
-    </main>
+    <div className='min-h-screen bg-zinc-900 text-zinc-100 flex'>
+      <Sidebar />
+      <div className='flex-1 flex flex-col'>
+        <Header />
+        <main className='p-4 grid gap-4 lg:grid-cols-2 flex-1 overflow-y-auto'>
+          <RiskSummary />
+          <Exposures />
+        </main>
+      </div>
+    </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useRiskFeed } from '@/hooks/useRiskFeed';
+
+export default function Header() {
+  const { data } = useRiskFeed();
+  const latest = data.at(-1);
+
+  return (
+    <header className="flex items-center justify-between py-4 px-6 bg-zinc-900 border-b border-zinc-700">
+      <h2 className="text-lg font-medium">Risk Dashboard</h2>
+      {latest && (
+        <div className="text-sm">
+          <span className="text-zinc-400 mr-2">Last P&amp;L:</span>
+          <span className={latest.pnl >= 0 ? 'text-emerald-400' : 'text-rose-400'}>
+            {latest.pnl.toLocaleString()}
+          </span>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+export default function Sidebar() {
+  return (
+    <aside className="bg-zinc-950 text-zinc-200 w-48 p-4 space-y-4">
+      <h1 className="text-xl font-bold tracking-wide">VASARA</h1>
+      <nav className="space-y-2">
+        <a className="block hover:text-cyan-400" href="#">Dashboard</a>
+        <a className="block hover:text-cyan-400" href="#">Exposures</a>
+        <a className="block hover:text-cyan-400" href="#">Settings</a>
+      </nav>
+    </aside>
+  );
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  darkMode: 'class',
+};


### PR DESCRIPTION
## Summary
- add sidebar and header components for dashboard vibe
- restructure page layout to use new components
- provide Tailwind config and `.env.example`
- document environment setup and allow `.env.example` in repo

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684db83ef1fc83288f7f40fefe0725c4